### PR TITLE
[2/N] Enable intel GPU for unsloth with torch.accelerator

### DIFF
--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -84,8 +84,9 @@ pass
 
 # First check if accelerator (NVIDIA GPU or INTEL GPU) is available
 # torch.accelerator is only supported after torch2.6, will crush here if torch.version < 2.6
-# this pr is only an example for torch.accelerator, if we use this as an solution
-# should add more check and provide better way to support torch before 2.6
+# this pr is only an example for torch.accelerator, if we use torch.accelerator as an solution
+# should add more check and provide a better way to support torch before 2.6
+# for more info related to torch.accelerator, please check: https://pytorch.org/docs/stable/accelerator.html
 if not torch.accelerator.is_available():
     raise NotImplementedError("Unsloth: Unsloth should use GPU accelerators, didn't found accelerator\n")
 
@@ -205,7 +206,7 @@ if torch.accelerate.current_accelerator().device_type == "cuda":
             )
     pass
 elif torch.accelerate.current_accelerator().device_type == "xpu":
-    # currently intel xpu will not support bnb
+    # currently intel xpu will not support bnb, will add support in the future
     # TODO: check triton for intel installed properly.
     pass
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -148,6 +148,7 @@ elif torch.accelerate.current_accelerator().device_type == "xpu":
 
 # For Gradio HF Spaces?
 # if "SPACE_AUTHOR_NAME" not in os.environ and "SPACE_REPO_NAME" not in os.environ:
+# here we did not change cuda specific code, only add a if check and tab for python grammar
 import triton
 if torch.accelerate.current_accelerator().device_type == "cuda":
     libcuda_dirs = lambda: None

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -142,6 +142,8 @@ if torch.accelerate.current_accelerator().device_type == "cuda":
         torch.cuda.is_bf16_supported = is_bf16_supported
     pass
 elif torch.accelerate.current_accelerator().device_type == "xpu":
+    # torch.xpu.is_bf16_supported() didn't have including_emulation
+    # set SUPPORTS_BFLOAT16 as torch.xpu.is_bf16_supported()
     SUPPORTS_BFLOAT16 = torch.xpu.is_bf16_supported()
 
 

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -86,7 +86,7 @@ pass
 if major_torch == 2 and minor_torch >= 6:
     DEVICE_TYPE = torch.accelerate.current_accelerator().device_type
 else:
-    DEVICE_TYPE = None
+    DEVICE_TYPE = "cuda" if torch.cuda.is_avaliable() else None
 
 # First check if CUDA is available ie a NVIDIA GPU is seen
 if DEVICE_TYPE is None:

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -16,10 +16,18 @@ import warnings, importlib, sys
 from packaging.version import Version
 import os, re, subprocess, inspect
 import numpy as np
-
+import torch
 # Check if modules that need patching are already imported
 critical_modules = ['trl', 'transformers', 'peft']
 already_imported = [mod for mod in critical_modules if mod in sys.modules]
+
+def get_device_type():
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+
+DEVICE_TYPE = get_device_type()
 
 # This check is critical because Unsloth optimizes these libraries by modifying
 # their code at import time. If they're imported first, the original (slower, 
@@ -48,9 +56,10 @@ os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 # Reduce VRAM usage by reducing fragmentation
 # And optimize pinning of memory
-os.environ["PYTORCH_CUDA_ALLOC_CONF"] = \
-    "expandable_segments:True,"\
-    "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
+if DEVICE_TYPE == "cuda":
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = \
+        "expandable_segments:True,"\
+        "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
 
 # [TODO] Check why some GPUs don't work
 #    "pinned_use_cuda_host_register:True,"\
@@ -89,8 +98,8 @@ elif (major_torch == 2) and (minor_torch < 2):
 pass
 
 # First check if CUDA is available ie a NVIDIA GPU is seen
-if not torch.cuda.is_available():
-    raise NotImplementedError("Unsloth: No NVIDIA GPU found? Unsloth currently only supports GPUs!")
+if not torch.cuda.is_available() and not torch.xpu.is_available():
+    raise NotImplementedError("Unsloth: No NVIDIA GPU or Intel XPU found? Unsloth currently only supports NVIDIA GPU or Intel XPU!")
 
 # Fix Xformers performance issues since 0.0.25
 import importlib.util
@@ -123,77 +132,92 @@ except:
 pass
 
 # Torch 2.4 has including_emulation
-major_version, minor_version = torch.cuda.get_device_capability()
-SUPPORTS_BFLOAT16 = (major_version >= 8)
+if DEVICE_TYPE == "cuda":
+    major_version, minor_version = torch.cuda.get_device_capability()
+    SUPPORTS_BFLOAT16 = (major_version >= 8)
 
-old_is_bf16_supported = torch.cuda.is_bf16_supported
-if "including_emulation" in str(inspect.signature(old_is_bf16_supported)):
-    def is_bf16_supported(including_emulation = False):
-        return old_is_bf16_supported(including_emulation)
-    torch.cuda.is_bf16_supported = is_bf16_supported
-else:
-    def is_bf16_supported(): return SUPPORTS_BFLOAT16
-    torch.cuda.is_bf16_supported = is_bf16_supported
-pass
+    old_is_bf16_supported = torch.cuda.is_bf16_supported
+    if "including_emulation" in str(inspect.signature(old_is_bf16_supported)):
+        def is_bf16_supported(including_emulation = False):
+            return old_is_bf16_supported(including_emulation)
+        torch.cuda.is_bf16_supported = is_bf16_supported
+    else:
+        def is_bf16_supported(): return SUPPORTS_BFLOAT16
+        torch.cuda.is_bf16_supported = is_bf16_supported
+    pass
+elif DEVICE_TYPE == "xpu":
+    # all xpu device support BF16
+    SUPPORTS_BFLOAT16 = False
+
+    def is_bf16_supported(): 
+        return SUPPORTS_BFLOAT16
+    torch.xpu.is_bf16_supported = is_bf16_supported
+
+
 
 # For Gradio HF Spaces?
 # if "SPACE_AUTHOR_NAME" not in os.environ and "SPACE_REPO_NAME" not in os.environ:
 import triton
-libcuda_dirs = lambda: None
-if Version(triton.__version__) >= Version("3.0.0"):
-    try: from triton.backends.nvidia.driver import libcuda_dirs
-    except: pass
-else: from triton.common.build import libcuda_dirs
+if DEVICE_TYPE == "cuda":
+    libcuda_dirs = lambda: None
+    if Version(triton.__version__) >= Version("3.0.0"):
+        try: from triton.backends.nvidia.driver import libcuda_dirs
+        except: pass
+    else: from triton.common.build import libcuda_dirs
 
-# Try loading bitsandbytes and triton
-import bitsandbytes as bnb
-try:
-    cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
-    libcuda_dirs()
-except:
-    warnings.warn(
-        "Unsloth: Running `ldconfig /usr/lib64-nvidia` to link CUDA."\
-    )
-
-    if os.path.exists("/usr/lib64-nvidia"):
-        os.system("ldconfig /usr/lib64-nvidia")
-    elif os.path.exists("/usr/local"):
-        # Sometimes bitsandbytes cannot be linked properly in Runpod for example
-        possible_cudas = subprocess.check_output(["ls", "-al", "/usr/local"]).decode("utf-8").split("\n")
-        find_cuda = re.compile(r"[\s](cuda\-[\d\.]{2,})$")
-        possible_cudas = [find_cuda.search(x) for x in possible_cudas]
-        possible_cudas = [x.group(1) for x in possible_cudas if x is not None]
-
-        # Try linking cuda folder, or everything in local
-        if len(possible_cudas) == 0:
-            os.system("ldconfig /usr/local/")
-        else:
-            find_number = re.compile(r"([\d\.]{2,})")
-            latest_cuda = np.argsort([float(find_number.search(x).group(1)) for x in possible_cudas])[::-1][0]
-            latest_cuda = possible_cudas[latest_cuda]
-            os.system(f"ldconfig /usr/local/{latest_cuda}")
-    pass
-
-    importlib.reload(bnb)
-    importlib.reload(triton)
+    # Try loading bitsandbytes and triton
+    import bitsandbytes as bnb
     try:
-        libcuda_dirs = lambda: None
-        if Version(triton.__version__) >= Version("3.0.0"):
-            try: from triton.backends.nvidia.driver import libcuda_dirs
-            except: pass
-        else: from triton.common.build import libcuda_dirs
         cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
         libcuda_dirs()
     except:
         warnings.warn(
-            "Unsloth: CUDA is not linked properly.\n"\
-            "Try running `python -m bitsandbytes` then `python -m xformers.info`\n"\
-            "We tried running `ldconfig /usr/lib64-nvidia` ourselves, but it didn't work.\n"\
-            "You need to run in your terminal `sudo ldconfig /usr/lib64-nvidia` yourself, then import Unsloth.\n"\
-            "Also try `sudo ldconfig /usr/local/cuda-xx.x` - find the latest cuda version.\n"\
-            "Unsloth will still run for now, but maybe it might crash - let's hope it works!"
+            "Unsloth: Running `ldconfig /usr/lib64-nvidia` to link CUDA."\
         )
-pass
+
+        if os.path.exists("/usr/lib64-nvidia"):
+            os.system("ldconfig /usr/lib64-nvidia")
+        elif os.path.exists("/usr/local"):
+            # Sometimes bitsandbytes cannot be linked properly in Runpod for example
+            possible_cudas = subprocess.check_output(["ls", "-al", "/usr/local"]).decode("utf-8").split("\n")
+            find_cuda = re.compile(r"[\s](cuda\-[\d\.]{2,})$")
+            possible_cudas = [find_cuda.search(x) for x in possible_cudas]
+            possible_cudas = [x.group(1) for x in possible_cudas if x is not None]
+
+            # Try linking cuda folder, or everything in local
+            if len(possible_cudas) == 0:
+                os.system("ldconfig /usr/local/")
+            else:
+                find_number = re.compile(r"([\d\.]{2,})")
+                latest_cuda = np.argsort([float(find_number.search(x).group(1)) for x in possible_cudas])[::-1][0]
+                latest_cuda = possible_cudas[latest_cuda]
+                os.system(f"ldconfig /usr/local/{latest_cuda}")
+        pass
+
+        importlib.reload(bnb)
+        importlib.reload(triton)
+        try:
+            libcuda_dirs = lambda: None
+            if Version(triton.__version__) >= Version("3.0.0"):
+                try: from triton.backends.nvidia.driver import libcuda_dirs
+                except: pass
+            else: from triton.common.build import libcuda_dirs
+            cdequantize_blockwise_fp32 = bnb.functional.lib.cdequantize_blockwise_fp32
+            libcuda_dirs()
+        except:
+            warnings.warn(
+                "Unsloth: CUDA is not linked properly.\n"\
+                "Try running `python -m bitsandbytes` then `python -m xformers.info`\n"\
+                "We tried running `ldconfig /usr/lib64-nvidia` ourselves, but it didn't work.\n"\
+                "You need to run in your terminal `sudo ldconfig /usr/lib64-nvidia` yourself, then import Unsloth.\n"\
+                "Also try `sudo ldconfig /usr/local/cuda-xx.x` - find the latest cuda version.\n"\
+                "Unsloth will still run for now, but maybe it might crash - let's hope it works!"
+            )
+    pass
+elif DEVICE_TYPE == "xpu":
+    # currently intel xpu will not support bnb
+    # TODO: check triton for intel installed properly.
+    pass
 
 # Check for unsloth_zoo
 try:

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -46,13 +46,6 @@ pass
 # Fixes https://github.com/unslothai/unsloth/issues/1266
 os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
-# Reduce VRAM usage by reducing fragmentation
-# And optimize pinning of memory
-if DEVICE_TYPE == "cuda":
-    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = \
-        "expandable_segments:True,"\
-        "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
-
 # [TODO] Check why some GPUs don't work
 #    "pinned_use_cuda_host_register:True,"\
 #    "pinned_num_register_threads:8"
@@ -83,6 +76,13 @@ def get_device_type():
         return "xpu"
 
 DEVICE_TYPE = get_device_type()
+
+# Reduce VRAM usage by reducing fragmentation
+# And optimize pinning of memory
+if DEVICE_TYPE == "cuda":
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = \
+        "expandable_segments:True,"\
+        "roundup_power2_divisions:[32:256,64:128,256:64,>:32]"
 
 # We support Pytorch 2
 # Fixes https://github.com/unslothai/unsloth/issues/38

--- a/unsloth/__init__.py
+++ b/unsloth/__init__.py
@@ -16,18 +16,10 @@ import warnings, importlib, sys
 from packaging.version import Version
 import os, re, subprocess, inspect
 import numpy as np
-import torch
+
 # Check if modules that need patching are already imported
 critical_modules = ['trl', 'transformers', 'peft']
 already_imported = [mod for mod in critical_modules if mod in sys.modules]
-
-def get_device_type():
-    if torch.cuda.is_available():
-        return "cuda"
-    elif torch.xpu.is_available():
-        return "xpu"
-
-DEVICE_TYPE = get_device_type()
 
 # This check is critical because Unsloth optimizes these libraries by modifying
 # their code at import time. If they're imported first, the original (slower, 
@@ -83,6 +75,14 @@ except ModuleNotFoundError:
 except Exception as exception:
     raise exception
 pass
+
+def get_device_type():
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.xpu.is_available():
+        return "xpu"
+
+DEVICE_TYPE = get_device_type()
 
 # We support Pytorch 2
 # Fixes https://github.com/unslothai/unsloth/issues/38


### PR DESCRIPTION
Hi unsloth, we are going to support unsloth intel GPU with several prs and this is the second pr.

- [x] add intel dependent packages for PyTorch 2.6 in pyproject.toml
- [x] generalize device types and refactor device-bias code in init.py
- [ ] refactor device-bias code in utils
- [ ] refactor device-bias code in kernels
- [ ] refactor device-bias code for unsloth-zoo
- [ ] refactor device-bias code for models


For the first step we are aiming to support several models with LoRA, and increase our feature in the future (including BNB, FlashAttention, xformers).

For cuda specific path, we didn't change the logics, only add check and tab to pass python grammar.

It's Like:
if torch.accelerate.current_accelerator().device_type == "cuda":
    cuda related
elif torch.accelerate.current_accelerator().device_type == "xpu":
    xpu related
    
This pr is different from https://github.com/leizhenyuan/unsloth/pull/7 as we are using torch.accelerator. The pros and cons for torch.accelerator are as follow:
Pros:
some api that both support by xpu and torch.cuda can use the same torch.accelerator api, up to now, torch.accelerator can only support 10 api , refer to https://pytorch.org/docs/stable/accelerator.html

Cons:
torch.accelerator is supported after pytorch2.6, so when using previous torch version, will fallback to torch.xxx.is_available usage.
torch.accelerator support some common api and will increase more api, but for device specific api, we still need to use torch.cuda/xpu.api
